### PR TITLE
Add a internal yarn representation class to decouple the file format support

### DIFF
--- a/file_format/yarnRepr.cpp
+++ b/file_format/yarnRepr.cpp
@@ -1,0 +1,35 @@
+#include "./yarnRepr.h"
+
+#include <Eigen/Core>
+#include <glm/common.hpp>
+
+#include <vector>
+
+#include "./yarns.h"
+
+namespace file_format {
+
+YarnRepr::YarnRepr(file_format::Yarns::Yarns yarns) {
+  for (auto yarn : yarns.yarns) {
+    int nPoints = yarn.points.size();
+
+    // Construct point list
+    Eigen::MatrixXf P(nPoints, 3);
+    for (int i = 0; i < nPoints; i++) {
+      P(i, 0) = yarn.points[i][0];
+      P(i, 1) = yarn.points[i][1];
+      P(i, 2) = yarn.points[i][2];
+    }
+
+    // Other meta data
+    Yarn internalYarn;
+    internalYarn.points = P;
+    internalYarn.color = yarn.color;
+    internalYarn.radius = yarn.radius;
+
+    // Save
+    this->yarns.push_back(internalYarn);
+  }
+}
+
+}  // namespace file_format

--- a/file_format/yarnRepr.h
+++ b/file_format/yarnRepr.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <Eigen/Core>
+#include <glm/common.hpp>
+
+#include <vector>
+
+#include "./yarns.h"
+
+namespace file_format {
+
+// An internal representation of a yarn in the simulator
+struct Yarn {
+  // A list of 3D control points (row based)
+  Eigen::MatrixXf points;
+  // RGB color (in range 0-255)
+  glm::ivec3 color = glm::vec3(128, 128, 128);
+  // Yarn radius
+  float radius;
+};
+
+// An internal representation of yarns in the simulator 
+class YarnRepr {
+ public:
+  // Empty constructor
+  YarnRepr() {}
+  // Convert `.yarns` file to internal representation
+  YarnRepr(file_format::Yarns::Yarns yarns);
+
+  // Stores a list of yarns
+  std::vector<Yarn> yarns;
+};
+
+}  // namespace file_format

--- a/file_format/yarns.cpp
+++ b/file_format/yarns.cpp
@@ -7,6 +7,7 @@
 #include "./yarns.h"
 
 namespace file_format {
+namespace Yarns {
 
 // Internal structures used for yarns file format:
 struct YarnInfo {
@@ -224,5 +225,5 @@ void Yarns::save(std::string const &filename) const {
 
 }
 
-}; // namespace file_format
-
+}  // namespace Yarns
+}  // namespace file_format

--- a/file_format/yarns.h
+++ b/file_format/yarns.h
@@ -6,7 +6,8 @@
 #include <vector>
 #include <glm/glm.hpp>
 
-namespace file_format{
+namespace file_format {
+namespace Yarns {
 
 struct Checkpoint {
     uint32_t point;
@@ -41,4 +42,5 @@ public:
     std::vector< Unit > units;
 };
 
-}; // namespace file_format
+}  // namespace Yarns
+}  // namespace file_format

--- a/simulator/Simulator.cpp
+++ b/simulator/Simulator.cpp
@@ -1,7 +1,8 @@
 #include "Simulator.h"
 
-#include "SimulatorParams.h"
-#include "Helper.h"
+#include "./SimulatorParams.h"
+#include "./Helper.h"
+#include "../file_format/yarnRepr.h"
 
 #include <iostream>
 #include <Eigen/Core>
@@ -148,13 +149,15 @@ void Simulator::fastProjection() {
 // Simulator implementation
 //
 
-Simulator::Simulator(Eigen::MatrixXf q_, SimulatorParams params_) : params(params_) {
-	assert(q_.cols() == 3);
-
-	m = q_.rows();
+Simulator::Simulator(file_format::YarnRepr yarns, SimulatorParams params_) : params(params_) {
+	this->yarns = yarns;
+	if (yarns.yarns.size() > 0) {
+		q = yarns.yarns[0].points;
+	}
+	m = q.rows();
 
 	// Resize to vector 3m x 1
-	q = flatten(q_);
+	q = flatten(q);
 	// q.resize(3 * m, 1); won't work because Column-major
 
 
@@ -168,10 +171,6 @@ Simulator::Simulator(Eigen::MatrixXf q_, SimulatorParams params_) : params(param
 	constructMassMatrix();
 
 	std::cout << "Simulator Initialized" << std::endl;
-}
-
-Eigen::MatrixXf Simulator::getControlPoints() const {
-	return inflate(q, 3);
 }
 
 void Simulator::step() {

--- a/simulator/Simulator.h
+++ b/simulator/Simulator.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "SimulatorParams.h"
+#include "./SimulatorParams.h"
+#include "../file_format/yarnRepr.h"
 
 #include <Eigen/Core>
 #include <Eigen/Sparse>
@@ -16,6 +17,7 @@ namespace simulator {
 class Simulator {
 private:
   size_t m;
+  file_format::YarnRepr yarns;
   Eigen::MatrixXf q;
   SimulatorParams params;
   Eigen::SparseMatrix<float> M;
@@ -45,10 +47,10 @@ public:
   //
   // q_ : The #m x 3 matrix containing initial control points.
   // params_ : Simulation paramters
-  Simulator(Eigen::MatrixXf q_, SimulatorParams params_);
+  Simulator(file_format::YarnRepr yarns, SimulatorParams params_);
 
-  // Returns #m x 3 matrix containing the current control points.
-  Eigen::MatrixXf getControlPoints() const;
+  // Returns current yarns
+  const file_format::YarnRepr &getYarns() const { return this->yarns; };
 
   // Simulates next timestep.
   void step();


### PR DESCRIPTION
I created a new class `yarnRepr` as the internal representation of yarns. It removes unnecessary data from the `.yarns` file. However, we need to think about how to integrate it with the simulator. The integration is not complete.

I also modified the viewer to respect the color and radius information from the `.yarns` file.